### PR TITLE
适配2025年9月以后的新版Notion API

### DIFF
--- a/flomo2notion.py
+++ b/flomo2notion.py
@@ -20,7 +20,7 @@ class Flomo2Notion:
         self.uploader = Md2NotionUploader()
 
     def insert_memo(self, memo):
-        print("insert_memo:", memo)
+        print(f"insert_memo: slug={memo['slug']}")
         content_md = markdownify(memo['content'])
         parent = {"database_id": self.notion_helper.page_id, "type": "database_id"}
         content_text = html2text.html2text(memo['content'])
@@ -56,7 +56,7 @@ class Flomo2Notion:
         self.uploader.uploadSingleFileContent(self.notion_helper.client, content_md, page['id'])
 
     def update_memo(self, memo, page_id):
-        print("update_memo:", memo)
+        print(f"update_memo: slug={memo['slug']}")
 
         content_md = markdownify(memo['content'])
         # 只更新内容
@@ -110,7 +110,7 @@ class Flomo2Notion:
                 full_update = os.getenv("FULL_UPDATE", False)
                 interval_day = os.getenv("UPDATE_INTERVAL_DAY", 7)
                 if not full_update and not is_within_n_days(memo['updated_at'], interval_day):
-                    print("is_within_n_days slug:", memo['slug'])
+                    print(f"skip_memo: slug={memo['slug']} (not within update interval)")
                     continue
 
                 page_id = slug_map[memo['slug']]

--- a/notionify/md2notion.py
+++ b/notionify/md2notion.py
@@ -1,6 +1,7 @@
 import re, os
 from dotenv import load_dotenv
 from notion_client import Client
+from retrying import retry
 from notionify.Parser.md2block import read_file, read_file_content
 
 
@@ -274,6 +275,7 @@ class Md2NotionUploader:
                            }
                  }]
 
+    @retry(stop_max_attempt_number=3, wait_fixed=5000)
     def uploadBlock(self, blockDescriptor, notion, page_id, mdFilePath=None, imagePathFunc=None):
         """
         Uploads a single blockDescriptor for NotionPyRenderer as the child of another block

--- a/notionify/notion_helper.py
+++ b/notionify/notion_helper.py
@@ -18,6 +18,25 @@ class NotionHelper:
         self.client = Client(auth=os.getenv("NOTION_TOKEN"), log_level=logging.ERROR)
         self.page_id = extract_page_id(os.getenv("NOTION_PAGE"))
         self.__cache = {}
+        self.__data_source_cache = {}  # 缓存 database_id -> data_source_id 的映射
+
+    @retry(stop_max_attempt_number=3, wait_fixed=5000)
+    def get_data_source_id(self, database_id):
+        """从 database_id 获取 data_source_id（新 API 需要）"""
+        if database_id in self.__data_source_cache:
+            return self.__data_source_cache[database_id]
+
+        # 调用 databases.retrieve 获取数据库信息，其中包含 data_sources
+        response = self.client.databases.retrieve(database_id=database_id)
+        data_sources = response.get("data_sources", [])
+
+        if data_sources:
+            data_source_id = data_sources[0].get("id")
+            self.__data_source_cache[database_id] = data_source_id
+            return data_source_id
+
+        # 如果没有 data_sources，可能是旧版本 API，直接返回 database_id
+        return database_id
 
     @retry(stop_max_attempt_number=3, wait_fixed=5000)
     def clear_page_content(self, page_id):
@@ -56,7 +75,12 @@ class NotionHelper:
     @retry(stop_max_attempt_number=3, wait_fixed=5000)
     def query(self, **kwargs):
         kwargs = {k: v for k, v in kwargs.items() if v}
-        return self.client.databases.query(**kwargs)
+        # 新 API：将 database_id 转换为 data_source_id
+        if "database_id" in kwargs:
+            database_id = kwargs.pop("database_id")
+            data_source_id = self.get_data_source_id(database_id)
+            kwargs["data_source_id"] = data_source_id
+        return self.client.data_sources.query(**kwargs)
 
     @retry(stop_max_attempt_number=3, wait_fixed=5000)
     def get_block_children(self, id):
@@ -80,12 +104,15 @@ class NotionHelper:
     @retry(stop_max_attempt_number=3, wait_fixed=5000)
     def query_all(self, database_id):
         """获取database中所有的数据"""
+        # 新 API：将 database_id 转换为 data_source_id
+        data_source_id = self.get_data_source_id(database_id)
+
         results = []
         has_more = True
         start_cursor = None
         while has_more:
-            response = self.client.databases.query(
-                database_id=database_id,
+            response = self.client.data_sources.query(
+                data_source_id=data_source_id,
                 start_cursor=start_cursor,
                 page_size=100,
             )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests
-notion-client < 5.0.0
+notion-client<5.0.0
 github-heatmap
 retrying
 pendulum

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests
-notion-client<5.0.0
+notion-client>=2.7.0
 github-heatmap
 retrying
 pendulum

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests
-notion-client
+notion-client < 5.0.0
 github-heatmap
 retrying
 pendulum


### PR DESCRIPTION
This pull request updates the Notion integration to support the new Notion API, which uses `data_source_id` instead of `database_id` for querying databases. It introduces a method to map `database_id` to `data_source_id`, updates relevant query methods, and improves logging for memo operations.

**Notion API migration and enhancements:**

* Added a `get_data_source_id` method in `notion_helper.py` to cache and retrieve the `data_source_id` for a given `database_id`, supporting compatibility with the new Notion API.
* Updated the `query` and `query_all` methods to use `data_source_id` instead of `database_id`, ensuring correct operation with the new API endpoints. [[1]](diffhunk://#diff-959fc7da33b0ecfa7cd75626eab4ae08a90d5699a9d1c07b8b209fdafe5bcf4fL59-R83) [[2]](diffhunk://#diff-959fc7da33b0ecfa7cd75626eab4ae08a90d5699a9d1c07b8b209fdafe5bcf4fR107-R115)

**Logging improvements:**

* Improved logging in `flomo2notion.py` to print only the memo slug instead of the full memo object when inserting or updating memos, making logs more concise and readable. [[1]](diffhunk://#diff-88ce0de1ae2c8587cf7f77b16786bccb06a89909805a27caebb7211967ab7e4fL23-R23) [[2]](diffhunk://#diff-88ce0de1ae2c8587cf7f77b16786bccb06a89909805a27caebb7211967ab7e4fL59-R59)
* Enhanced log message when skipping memos not within the update interval, providing clearer context in the logs.